### PR TITLE
Replaced TestUtil with JavalinTest, upgraded javalin-bundle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin-bundle</artifactId>
-            <version>4.0.0</version>
+            <version>4.6.3</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/test/java/io/javalin/example/java/EndToEndTest.java
+++ b/src/test/java/io/javalin/example/java/EndToEndTest.java
@@ -2,7 +2,7 @@ package io.javalin.example.java;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.javalin.Javalin;
-import io.javalin.testtools.TestUtil;
+import io.javalin.testtools.JavalinTest;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -16,7 +16,7 @@ public class EndToEndTest {
 
     @Test
     public void UI_contains_correct_heading() {
-        TestUtil.test(app, (server, client) -> {
+        JavalinTest.test(app, (server, client) -> {
             WebDriverManager.chromedriver().setup();
             ChromeOptions options = new ChromeOptions();
             options.addArguments("--headless");

--- a/src/test/java/io/javalin/example/java/FunctionalTest.java
+++ b/src/test/java/io/javalin/example/java/FunctionalTest.java
@@ -2,7 +2,7 @@ package io.javalin.example.java;
 
 import io.javalin.Javalin;
 import io.javalin.plugin.json.JavalinJackson;
-import io.javalin.testtools.TestUtil;
+import io.javalin.testtools.JavalinTest;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,7 +14,7 @@ public class FunctionalTest {
 
     @Test
     public void GET_to_fetch_users_returns_list_of_users() {
-        TestUtil.test(app, (server, client) -> {
+        JavalinTest.test(app, (server, client) -> {
             assertThat(client.get("/users").code()).isEqualTo(200);
             assertThat(client.get("/users").body().string()).isEqualTo(usersJson);
         });

--- a/src/test/kotlin/io/javalin/example/kotlin/EndToEndTest.kt
+++ b/src/test/kotlin/io/javalin/example/kotlin/EndToEndTest.kt
@@ -1,7 +1,7 @@
 package io.javalin.example.kotlin
 
 import io.github.bonigarcia.wdm.WebDriverManager
-import io.javalin.testtools.TestUtil
+import io.javalin.testtools.JavalinTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.openqa.selenium.WebDriver
@@ -13,7 +13,7 @@ class EndToEndTest {
     private val app = Application("someDependency").app // inject any dependencies you might have
 
     @Test
-    fun `UI contains correct heading`() = TestUtil.test(app) { server, client ->
+    fun `UI contains correct heading`() = JavalinTest.test(app) { server, client ->
         WebDriverManager.chromedriver().setup()
         val driver: WebDriver = ChromeDriver(ChromeOptions().apply {
             addArguments("--headless")

--- a/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
+++ b/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
@@ -1,7 +1,7 @@
 package io.javalin.example.kotlin
 
 import io.javalin.plugin.json.JavalinJackson
-import io.javalin.testtools.TestUtil
+import io.javalin.testtools.JavalinTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -11,7 +11,7 @@ class FunctionalTest {
     private val usersJson = JavalinJackson().toJsonString(UserController.users)
 
     @Test
-    fun `GET to fetch users returns list of users`() = TestUtil.test(app) { server, client ->
+    fun `GET to fetch users returns list of users`() = JavalinTest.test(app) { server, client ->
         assertThat(client.get("/users").code).isEqualTo(200)
         assertThat(client.get("/users").body?.string()).isEqualTo(usersJson)
     }


### PR DESCRIPTION
TestUtil is deprecated and is used in testing tutorial.

Signed-off-by: Mikolaj Matuszewski <mikolaj.matuszewski@digitalnewagency.com>